### PR TITLE
Add `define_fdjvp ` and `fgrad` improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install jaxlib
+          python -m pip install jaxlib typing_extensions
           python -m pip install pytest wheel optax coverage
       - name: Pytest Check
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ experimental
 *.vscode/
 notes
 build
+playground.ipynb

--- a/finitediffx/__init__.py
+++ b/finitediffx/__init__.py
@@ -1,4 +1,18 @@
-from ._src.fgrad import fgrad
+# Copyright 2023 FiniteDiffX authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ._src.fgrad import Offset, define_fdjvp, fgrad
 from ._src.finite_diff import (
     curl,
     difference,
@@ -19,8 +33,10 @@ __all__ = (
     "laplacian",
     "hessian",
     "fgrad",
+    "Offset",
+    "define_fdjvp",
     "generate_finitediff_coeffs",
 )
 
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"

--- a/finitediffx/_src/__init__.py
+++ b/finitediffx/_src/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023 FiniteDiffX authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/finitediffx/_src/fgrad.py
+++ b/finitediffx/_src/fgrad.py
@@ -1,39 +1,59 @@
-# credits to Mahmoud Asem 2022 @KAIST
-
-# This file defines the fgrad function which is a finite difference approximation of jax.grad
-# for first order derivative, finite difference and automatic difference is approximated as the following
-# f(x + Δx) = f(x) + f'(x) Δx + f''(x) Δx^2 / 2 + f'''(x) Δx^3 / 6 + ...
-# f(x + ɛ Δx) = f(x) + f'(x) ɛ Δx + f''(x) ɛ^2 Δx^2 / 2 + f'''(x) ɛ^3 Δx^3 / 6 + ... , where ɛ^2 := 0 and ɛ != 0
-
+# Copyright 2023 FiniteDiffX authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from __future__ import annotations
 
 import functools as ft
-from typing import Callable
+from typing import Callable, NamedTuple, TypeVar, Union
 
 import jax
 import jax.numpy as jnp
+from typing_extensions import ParamSpec
 
 from finitediffx._src.utils import _generate_central_offsets, generate_finitediff_coeffs
 
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class Offset(NamedTuple):
+    """Convinience class for finite difference offsets used inside `fgrad`"""
+
+    accuracy: int
+
+
+OffsetType = Union[jax.Array, Offset]
+StepsizeType = Union[jax.Array, float]
+
 
 def _evaluate_func_at_shifted_steps_along_argnum(
-    func: Callable,
+    func: Callable[P, T],
     *,
     coeffs: jax.Array,
-    offsets: tuple[float | int, ...],
+    offsets: jax.Array,
     argnum: int,
-    step_size: float,
+    step_size: StepsizeType,
     derivative: int,
-) -> Callable:
+):
     if not isinstance(argnum, int) or argnum < 0:
         raise ValueError(f"argnum must be a non-negative integer, got {argnum}")
 
-    DX = jnp.array(offsets) * step_size
+    dxs = offsets * step_size
 
     def wrapper(*args, **kwargs):
         # yield function output at shifted points
-        for coeff, dx in zip(coeffs, DX):
+        for coeff, dx in zip(coeffs, dxs):
             shifted_args = list(args)
             shifted_args[argnum] += dx
             yield coeff * func(*shifted_args, **kwargs) / (step_size**derivative)
@@ -41,98 +61,230 @@ def _evaluate_func_at_shifted_steps_along_argnum(
     return wrapper
 
 
+def _canonicalize_step_size(
+    step_size: StepsizeType | tuple[StepsizeType, ...] | None,
+    length: int | None,
+    derivative: int,
+) -> tuple[StepsizeType, ...] | StepsizeType:
+    # return non-tuple values if length is None
+    if isinstance(step_size, (jax.Array, float)):
+        return ((step_size,) * length) if length else step_size
+    if step_size is None:
+        default = (2) ** (-23 / (2 * derivative))
+        return ((default,) * length) if length else default
+
+    if isinstance(step_size, tuple) and length:
+        assert len(step_size) == length, f"step_size must be a tuple of length {length}"
+        step_size = list(step_size)
+        for i, s in enumerate(step_size):
+            if s is None:
+                step_size[i] = (2) ** (-23 / (2 * derivative))
+            elif not isinstance(s, (jax.Array, float)):
+                raise TypeError(f"{type(s)} not in {(jax.Array, float)}")
+        return tuple(step_size)
+
+    raise TypeError(
+        f"`step_size` must be of type:\n"
+        f"- `jax.Array`\n"
+        f"- `float`\n"
+        f"- tuple of `jax.Array` or `float` for tuple argnums.\n"
+        f"but got {type(step_size)=}"
+    )
+
+
+def _canonicalize_offsets(
+    offsets: tuple[OffsetType | None, ...] | OffsetType | None,
+    length: int,
+    derivative: int,
+) -> tuple[OffsetType, ...] | OffsetType:
+    # single value
+    if isinstance(offsets, Offset):
+        if offsets.accuracy < 2:
+            raise ValueError(f"offset accuracy must be >=2, got {offsets.accuracy}")
+        offsets = jnp.array(_generate_central_offsets(derivative, offsets.accuracy))
+        return ((offsets,) * length) if length else offsets
+    if isinstance(offsets, jax.Array):
+        return ((offsets,) * length) if length else offsets
+
+    if isinstance(offsets, tuple) and length:
+        assert len(offsets) == length, f"`offsets` must be a tuple of length {length}"
+        offsets = list(offsets)
+        for i, o in enumerate(offsets):
+            if isinstance(o, Offset):
+                if o.accuracy < 2:
+                    raise ValueError(f"offset accuracy must be >=2, got {o.accuracy}")
+                o = jnp.array(_generate_central_offsets(derivative, o.accuracy))
+                offsets[i] = o
+            elif not isinstance(o, (Offset, jax.Array)):
+                raise TypeError(f"{type(o)} not an Offset")
+
+        return tuple(offsets)
+
+    raise TypeError(
+        f"`offsets` must be of type:\n"
+        f"- `Offset`\n"
+        f"- `jax.Array`\n"
+        f"- tuple of `Offset` or `jax.Array` for tuple argnums.\n"
+        f"but got {type(offsets)=}"
+    )
+
+
 def fgrad(
     func: Callable,
     *,
-    argnums: int = 0,
-    step_size: float = None,
-    offsets: tuple[float | int, ...] = None,
+    argnums: int | tuple[int, ...] = 0,
+    step_size: StepsizeType | None = None,
+    offsets: OffsetType = Offset(accuracy=3),
     derivative: int = 1,
-    accuracy: int = 3,
 ) -> Callable:
     """Finite difference derivative of a function with respect to one of its arguments.
     similar to jax.grad but with finite difference approximation
 
-    This function could be useful in certain situations for example
-    >>> import jax
-    >>> jax.config.update("jax_enable_x64", True)
-    >>> f = lambda x : x**10
-    >>> def repeated_grad(f, n):
-    ...     return f if n==0 else jax.grad(repeated_grad(f, n-1))
-
-    >>> df_grad = jax.jit(repeated_grad(f,10))
-    >>> %timeit df_grad(1.)
-    4.83 µs ± 4.3 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
-
-    >>> df_fgrad = jax.jit(fgrad(f, argnums=0, derivative=10, accuracy=2))
-    >>> %timeit df_fgrad(1.)
-    2.45 µs ± 63.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
-
     Args:
         func: function to differentiate
-        argnums:
-            argument number to differentiate. Defaults to 0.
-            If a tuple is passed, the function is differentiated with respect to all the arguments in the tuple.
-        step_size: step size for the finite difference stencil. Defaults to None.
-        offsets: offsets for the finite difference stencil. Defaults to None.
+        argnums: argument number to differentiate. Defaults to 0.
+            If a tuple is passed, the function is differentiated with respect to
+            all the arguments in the tuple.
+        step_size: step size for the finite difference stencil. If `None`, the step size
+            is set to `(2) ** (-23 / (2 * derivative))`
+        offsets: offsets for the finite difference stencil. Accepted types are:
+            - `jax.Array` defining location of function evaluation points.
+            - `Offset` with accuracy field to automatically generate offsets.
         derivative: derivative order. Defaults to 1.
-        accuracy: accuracy of the finite difference stencil. Defaults to 2. used to generate offsets if not provided.
 
     Returns:
         Callable: derivative of the function
 
     Example:
-        >>> def f(x):
-        ...     return x**2
-        >>> df = fgrad(f)
-        >>> df(2.0)
-        DeviceArray(4., dtype=float32)
+        >>> import finitediffx as fdx
+        >>> import jax
+        >>> import jax.numpy as jnp
+
+        >>> def f(x, y):
+        ...    return x**2 + y**2
+
+        >>> df=fdx.fgrad(
+        ...    func=f,
+        ...    argnums=1,  # differentiate with respect to y
+        ...    offsets=fdx.Offset(accuracy=2)  # use 2nd order accurate finite difference
+        ... )
+
+        >>> df(2.0, 3.0)
+        Array(6., dtype=float32)
+
     """
-    if offsets is None:
-        # if offsets is not provided, generate them based on accuracy
-        # otherwise, use the provided offsets and discard accuracy
-        if accuracy < 2:
-            raise ValueError(f"accuracy must be >= 2, got {accuracy}")
-        # generate central offsets based on accuracy
-        offsets = _generate_central_offsets(derivative, accuracy=accuracy)
-
-    if step_size is None:
-        # generate step size based on accuracy
-        # the best step size = 2**(-23 / (2 * derivative))
-        step_size = (2) ** (-23 / (2 * derivative))
-
-    # finite difference coefficients
-    coeffs = generate_finitediff_coeffs(offsets, derivative)
-
-    # TODO: edit docstring of the differentiated function
+    func.__doc__ = (
+        f"Finite difference derivative of {func.__name__} w.r.t {argnums=}"
+        f"\n\n{func.__doc__}"
+    )
 
     if isinstance(argnums, int):
         # fgrad(func, argnums=0)
+        kwargs = dict(length=None, derivative=derivative)
+        step_size = _canonicalize_step_size(step_size, **kwargs)
+        offsets = _canonicalize_offsets(offsets, **kwargs)
         dfunc = _evaluate_func_at_shifted_steps_along_argnum(
-            func,
-            coeffs=coeffs,
+            func=func,
+            coeffs=generate_finitediff_coeffs(offsets, derivative),
             offsets=offsets,
-            argnum=argnums,
             step_size=step_size,
             derivative=derivative,
+            argnum=argnums,
         )
+
         return ft.wraps(func)(lambda *a, **k: sum(dfunc(*a, **k)))
 
     if isinstance(argnums, tuple):
         # fgrad(func, argnums=(0,1))
         # return a tuple of derivatives evaluated at each argnum
         # this behavior is similar to jax.grad(func, argnums=(...))
+        kwargs = dict(length=len(argnums), derivative=derivative)
+
         dfuncs = [
             _evaluate_func_at_shifted_steps_along_argnum(
-                func,
-                coeffs=coeffs,
-                offsets=offsets,
-                argnum=argnum,
-                step_size=step_size,
+                func=func,
+                coeffs=generate_finitediff_coeffs(offsets_i, derivative),
+                offsets=offsets_i,
+                step_size=step_size_i,
                 derivative=derivative,
+                argnum=argnum_i,
             )
-            for argnum in argnums
+            for offsets_i, step_size_i, argnum_i in zip(
+                _canonicalize_offsets(offsets, **kwargs),
+                _canonicalize_step_size(step_size, **kwargs),
+                argnums,
+            )
         ]
         return ft.wraps(func)(lambda *a, **k: tuple(sum(df(*a, **k)) for df in dfuncs))
 
     raise ValueError(f"argnums must be an int or a tuple of ints, got {argnums}")
+
+
+def define_fdjvp(
+    func: Callable[P, T],
+    offsets: tuple[OffsetType, ...] | OffsetType = Offset(accuracy=2),
+    step_size: tuple[float, ...] | float | None = None,
+) -> Callable[P, T]:
+    """Define the JVP rule for a function using finite difference.
+
+    Args:
+        func: function to define the JVP rule for
+        offsets: offsets for the finite difference stencil. Accepted types are:
+            - `jax.Array` defining location of function evaluation points.
+            - `Offset` with accuracy field to automatically generate offsets.
+            - tuple of `Offset` or `jax.Array` defining offsets for each argument.
+        step_size: step size for the finite difference stencil. Accepted types are:
+            - `float` defining the step size for all arguments.
+            - `tuple` of `float` defining the step size for each argument.
+            - `None` to use the default step size for each argument.
+
+    Returns:
+        Callable: function with JVP rule defined using finite difference.
+
+    Note:
+        - This function is motivated by [`JEP`](https://github.com/google/jax/issues/15425)
+        - This function can be used with `jax.pure_callback` to define the JVP
+            rule for a function that is not differentiable by JAX.
+
+        Example:
+            >>> import jax
+            >>> import jax.numpy as jnp
+            >>> import finitediffx as fdx
+            >>> import functools as ft
+            >>> import numpy as onp
+            >>> def wrap_pure_callback(func):
+            ...     @ft.wraps(func)
+            ...     def wrapper(*args, **kwargs):
+            ...         args = [jnp.asarray(arg) for arg in args]
+            ...         func_ = lambda *a, **k: func(*a, **k).astype(a[0].dtype)
+            ...         dtype_ = jax.ShapeDtypeStruct(
+            ...             jnp.broadcast_shapes(*[ai.shape for ai in args]),
+            ...             args[0].dtype,
+            ...         )
+            ...         return jax.pure_callback(func_, dtype_, *args, **kwargs, vectorized=True)
+            ...     return wrapper
+
+            >>> @jax.jit
+            ... @jax.grad
+            ... @fdx.define_fdjvp
+            ... @wrap_pure_callback
+            ... def numpy_func(x, y):
+            ...     return onp.sin(x) + onp.cos(y)
+            >>> print(numpy_func(1., 2.))
+            0.5402466
+    """
+    func = jax.custom_jvp(func)
+
+    @func.defjvp
+    def _(primals, tangents):
+        kwargs = dict(length=len(primals), derivative=1)
+        step_size_ = _canonicalize_step_size(step_size, **kwargs)
+        offsets_ = _canonicalize_offsets(offsets, **kwargs)
+        primal_out = func(*primals)
+        tangent_out = sum(
+            fgrad(func, argnums=i, step_size=si, offsets=oi)(*primals) * ti
+            for i, (si, oi, ti) in enumerate(zip(step_size_, offsets_, tangents))
+        )
+        return jnp.array(primal_out), jnp.array(tangent_out)
+
+    return func

--- a/finitediffx/_src/finite_diff.py
+++ b/finitediffx/_src/finite_diff.py
@@ -530,7 +530,12 @@ def laplacian(
 
     return sum(
         difference(
-            array, accuracy=acc, step_size=step, derivative=2, method=method, axis=axis
+            array,
+            accuracy=acc,
+            step_size=step,
+            derivative=2,
+            method=method,
+            axis=axis,
         )
         for axis, (acc, step) in enumerate(zip(accuracy, step_size))
     )
@@ -566,10 +571,18 @@ def _curl_2d(
         >>> curl = curl_2d(F, accuracy=4, step_size=dx)
     """
     dF1dY = difference(
-        array[0], accuracy=accuracy[1], step_size=step_size[1], method=method, axis=1
+        array[0],
+        accuracy=accuracy[1],
+        step_size=step_size[1],
+        method=method,
+        axis=1,
     )
     dF2dX = difference(
-        array[1], accuracy=accuracy[0], step_size=step_size[0], method=method, axis=0
+        array[1],
+        accuracy=accuracy[0],
+        step_size=step_size[0],
+        method=method,
+        axis=0,
     )
 
     result = dF2dX - dF1dY
@@ -588,24 +601,48 @@ def _curl_3d(
     method: str = "central",
 ) -> jax.Array:
     dF1dY = difference(
-        array[0], accuracy=accuracy[1], step_size=step_size[1], method=method, axis=1
+        array[0],
+        accuracy=accuracy[1],
+        step_size=step_size[1],
+        method=method,
+        axis=1,
     )
     dF1dZ = difference(
-        array[0], accuracy=accuracy[2], step_size=step_size[2], method=method, axis=2
+        array[0],
+        accuracy=accuracy[2],
+        step_size=step_size[2],
+        method=method,
+        axis=2,
     )
 
     dF2dX = difference(
-        array[1], accuracy=accuracy[0], step_size=step_size[0], method=method, axis=0
+        array[1],
+        accuracy=accuracy[0],
+        step_size=step_size[0],
+        method=method,
+        axis=0,
     )
     dF2dZ = difference(
-        array[1], accuracy=accuracy[2], step_size=step_size[2], method=method, axis=2
+        array[1],
+        accuracy=accuracy[2],
+        step_size=step_size[2],
+        method=method,
+        axis=2,
     )
 
     dF3dX = difference(
-        array[2], accuracy=accuracy[0], step_size=step_size[0], method=method, axis=0
+        array[2],
+        accuracy=accuracy[0],
+        step_size=step_size[0],
+        method=method,
+        axis=0,
     )
     dF3dY = difference(
-        array[2], accuracy=accuracy[1], step_size=step_size[1], method=method, axis=1
+        array[2],
+        accuracy=accuracy[1],
+        step_size=step_size[1],
+        method=method,
+        axis=1,
     )
 
     return jnp.stack(

--- a/finitediffx/_src/finite_diff.py
+++ b/finitediffx/_src/finite_diff.py
@@ -1,7 +1,16 @@
-# credits to Mahmoud Asem 2022 @KAIST
-# functions that operate on arrays
-# higher accuracy finite difference gradient might require
-# setting jax.config.update("jax_enable_x64", True)
+# Copyright 2023 FiniteDiffX authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from __future__ import annotations
 
@@ -184,22 +193,24 @@ def difference(
     Example:
         >>> # dydx of a 2D array
         >>> import finitediffx as fdx
-        >>> x, y = [jnp.linspace(0, 1, 100)] * 2
-        >>> dx, dy = x[1] - x[0], y[1] - y[0]
-        >>> X, Y = jnp.meshgrid(x, y, indexing="ij")
-        >>> F =  jnp.sin(X) * jnp.cos(Y)
-        >>> dFdX = fdx.difference(F, step_size=dx, axis=0, accuracy=3, method="central")
-        >>> dFdXdY = fdx.difference(dFdX, step_size=dy, axis=1, accuracy=3, method="central")
-
-        >>> # 1d finite difference derivative
-        >>> x = jnp.array([1.2, 1.3, 2.2, 3., 4.5, 5.5, 6., 7., 8., 20.])
-        >>> difference(x, accuracy=1)
-        [ 0.0999999  0.5        0.85       1.15       1.25       0.75 0.75       1.         6.5       12.       ]
+        >>> import jax.numpy as jnp
+        >>> import jax
+        >>> with jax.experimental.enable_x64():
+        ...     x, y = [jnp.linspace(0, 1, 100)] * 2
+        ...     dx, dy = x[1] - x[0], y[1] - y[0]
+        ...     X, Y = jnp.meshgrid(x, y, indexing="ij")
+        ...     F =  jnp.sin(X) * jnp.cos(Y)
+        ...     dFdX = fdx.difference(F, step_size=dx, axis=0, accuracy=3, method="central")
+        ...     dFdXdY = fdx.difference(dFdX, step_size=dy, axis=1, accuracy=3, method="central")
+        ...     # 1d finite difference derivative
+        ...     x = jnp.array([1.2, 1.3, 2.2, 3., 4.5, 5.5, 6., 7., 8., 20.])
+        ...     print(fdx.difference(x, accuracy=1))
+        [ 0.1   0.5   0.85  1.15  1.25  0.75  0.75  1.    6.5  12.  ]
 
 
     Note:
-        Handling of boundary points is done by applying forward/backward difference to the first/last element
-        and central difference to the interior elements.
+        Handling of boundary points is done by applying forward/backward difference
+        to the first/last element and central difference to the interior elements.
         For the previous example, the following steps are performed:
 
         - apply forward difference to the first element with accuracy 1
@@ -276,11 +287,12 @@ def difference(
             right_offsets=right_offsets,
         ) / (step_size**derivative)
 
-    msg = f"Size of the array along axis {axis} is smaller than the number of points required"
-    msg += f" for the accuracy {accuracy} and derivative {derivative} requested"
-    msg += f".\nSize must be larger than {len(left_offsets)}, but got {size}"
-    msg += f".\nMethod should be 'central', 'forward', 'backward', but got {method}"
-    raise ValueError(msg)
+    raise ValueError(
+        f"Size of the array along axis {axis} is smaller than the number of points required"
+        f" for the accuracy {accuracy} and derivative {derivative} requested"
+        f".\nSize must be larger than {len(left_offsets)}, but got {size}"
+        f".\nMethod should be 'central', 'forward', 'backward', but got {method}"
+    )
 
 
 @ft.partial(jax.jit, static_argnames=("accuracy", "method"))
@@ -304,14 +316,19 @@ def gradient(
 
     Example:
         >>> # ∇F of a 2D array
-        >>> x, y = [jnp.linspace(0, 1, 100)] * 2
-        >>> dx, dy = x[1] - x[0], y[1] - y[0]
-        >>> X, Y = jnp.meshgrid(x, y, indexing="ij")
-        >>> Z = X**2 + Y**3
-        >>> dZdX , dZdY = gradient(Z, step_size=(dx,dy))
-        >>> dZdx_true, dZdy_true= 2*X , 3*Y**2
-        >>> numpy.testing.assert_allclose(dZdx, dZdx_true, atol=1e-4)
-        >>> numpy.testing.assert_allclose(dZdy, dZdy_true, atol=1e-4)
+        >>> import finitediffx as fdx
+        >>> import jax.numpy as jnp
+        >>> import numpy.testing as npt
+        >>> import jax
+        >>> with jax.experimental.enable_x64():
+        ...     x, y = [jnp.linspace(0, 1, 100)] * 2
+        ...     dx, dy = x[1] - x[0], y[1] - y[0]
+        ...     X, Y = jnp.meshgrid(x, y, indexing="ij")
+        ...     Z = X**2 + Y**3
+        ...     dZdX , dZdY = fdx.gradient(Z, step_size=(dx,dy), accuracy=5)
+        ...     dZdX_true, dZdY_true= 2*X , 3*Y**2
+        ...     npt.assert_allclose(dZdX, dZdX_true, atol=1e-4)
+        ...     npt.assert_allclose(dZdY, dZdY_true, atol=1e-4)
     """
     accuracy = _check_and_return(accuracy, array.ndim, "accuracy")
     step_size = _check_and_return(step_size, array.ndim, "step_size")
@@ -355,6 +372,10 @@ def jacobian(
         >>> # F: R^2 -> R^2
         >>> # F = [ x^2*y, 5x+siny ]
         >>> # JF = [ [2xy, x^2], [5, cos(y)] ]
+        >>> import finitediffx as fdx
+        >>> import jax.numpy as jnp
+        >>> import numpy.testing as npt
+        >>> import jax
         >>> with jax.experimental.enable_x64():
         ...    x, y = [jnp.linspace(-1, 1, 100)] * 2
         ...    dx, dy = x[1] - x[0], y[1] - y[0]
@@ -401,6 +422,9 @@ def divergence(
 
     Example:
         >>> # ∇.F of a 2D array
+        >>> import finitediffx as fdx
+        >>> import jax.numpy as jnp
+        >>> import numpy.testing as npt
         >>> x, y = [jnp.linspace(0, 1, 100)] * 2
         >>> dx, dy = x[1] - x[0], y[1] - y[0]
         >>> X, Y = jnp.meshgrid(x, y, indexing="ij")
@@ -409,7 +433,7 @@ def divergence(
         >>> F = jnp.stack([F1, F2], axis=0) # 2D vector field F = (F1, F2)
         >>> divZ = divergence(F,step_size=(dx,dy), accuracy=7, keepdims=False)
         >>> divZ_true = 2*X + 3*Y**2  # (dF1/dx) + (dF2/dy)
-        >>> numpy.testing.assert_allclose(divZ, divZ_true, atol=5e-4)
+        >>> npt.assert_allclose(divZ, divZ_true, atol=5e-4)
     """
     accuracy = _check_and_return(accuracy, array.ndim - 1, "accuracy")
     step_size = _check_and_return(step_size, array.ndim - 1, "step_size")
@@ -450,14 +474,18 @@ def hessian(
     Index notation: d2F/dxij
 
     Example:
-        >>> x, y = [jnp.linspace(-1, 1, 100)] * 2
-        >>> dx, dy = x[1] - x[0], y[1] - y[0]
-        >>> X, Y = jnp.meshgrid(x, y, indexing="ij")
-
-        >>> F = X**2 * Y
-        >>> H = hessian(F, accuracy=4, step_size=(dx, dy))
-        >>> H_true = jnp.array([[2 * Y, 2 * X], [2 * X, jnp.zeros_like(X)]])
-        >>> npt.assert_allclose(H, H_true, atol=1e-7)
+        >>> import finitediffx as fdx
+        >>> import jax.numpy as jnp
+        >>> import numpy.testing as npt
+        >>> import jax
+        >>> with jax.experimental.enable_x64():
+        ...     x, y = [jnp.linspace(-1, 1, 100)] * 2
+        ...     dx, dy = x[1] - x[0], y[1] - y[0]
+        ...     X, Y = jnp.meshgrid(x, y, indexing="ij")
+        ...     F = X**2 * Y
+        ...     H = fdx.hessian(F, accuracy=4, step_size=(dx, dy))
+        ...     H_true = jnp.array([[2 * Y, 2 * X], [2 * X, jnp.zeros_like(X)]])
+        ...     npt.assert_allclose(H, H_true, atol=1e-7)
     """
     accuracy = _check_and_return(accuracy, array.ndim, "accuracy")
     step_size = _check_and_return(step_size, array.ndim, "step_size")
@@ -516,14 +544,18 @@ def laplacian(
 
     Index notation: d2F/dxi2
     Example:
-        >>> # ΔF array
-        >>> x, y = [jnp.linspace(0, 1, 100)] * 2
-        >>> dx, dy = x[1] - x[0], y[1] - y[0]
-        >>> X, Y = jnp.meshgrid(x, y, indexing="ij")
-        >>> Z = X**4 + Y**3
-        >>> laplacianZ = laplacian(Z, step_size=(dx,dy))
-        >>> laplacianZ_true = 12*X**2 + 6*Y
-        >>> numpy.testing.assert_allclose(laplacianZ, laplacianZ_true, atol=1e-4)
+        >>> import finitediffx as fdx
+        >>> import jax.numpy as jnp
+        >>> import numpy.testing as npt
+        >>> import jax
+        >>> with jax.experimental.enable_x64():
+        ...    x, y = [jnp.linspace(0, 1, 100)] * 2
+        ...    dx, dy = x[1] - x[0], y[1] - y[0]
+        ...    X, Y = jnp.meshgrid(x, y, indexing="ij")
+        ...    Z = X**4 + Y**3
+        ...    laplacianZ = fdx.laplacian(Z, step_size=(dx,dy), accuracy=10)
+        ...    laplacianZ_true = 12*X**2 + 6*Y
+        ...    npt.assert_allclose(laplacianZ, laplacianZ_true, atol=1e-4)
     """
     accuracy = _check_and_return(accuracy, array.ndim, "accuracy")
     step_size = _check_and_return(step_size, array.ndim, "step_size")
@@ -549,27 +581,6 @@ def _curl_2d(
     method: MethodKind = "central",
     keepdims: bool = True,
 ) -> jax.Array:
-    """Compute the ∇×F of input array where F is a vector field whose components are the first axis of x
-    and returns a vector field
-
-    Index notation: εijk dFk/dxj
-
-    Args:
-        x: input array where the leading axis is the dimension of the vector field
-        accuracy: accuracy order of the gradient. Default is 1, can be a tuple for each axis
-        step_size: step size. Default is 1, can be a tuple for each axis
-        method: the method to use (forward, central, backward). Default is central
-        keepdims: whether to keep the leading dimension of the vector field
-
-    Example:
-        >>> x,y = [jnp.linspace(-1,1,50)]*2
-        >>> dx,dy = x[1]-x[0],y[1]-y[0]
-        >>> X,Y = jnp.meshgrid(x,y, indexing="ij")
-        >>> F1 = jnp.sin(Y)
-        >>> F2 = jnp.cos(X)
-        >>> F = jnp.stack([F1,F2], axis=0)
-        >>> curl = curl_2d(F, accuracy=4, step_size=dx)
-    """
     dF1dY = difference(
         array[0],
         accuracy=accuracy[1],
@@ -680,17 +691,21 @@ def curl(
         >>> # Curl for a 3D vector field is defined as
         >>> # F = (F1, F2, F3)
         >>> # ∇×F = (dF3/dy - dF2/dz, dF1/dz - dF3/dx, dF2/dx - dF1/dy)
-        >>> jax.config.update("jax_enable_x64", True)
-        >>> x,y,z = [jnp.linspace(0, 1, 100)] * 3
-        >>> dx,dy,dz = x[1]-x[0], y[1]-y[0], z[1]-z[0]
-        >>> X,Y,Z = jnp.meshgrid(x,y,z, indexing="ij")
-        >>> F1 = X**2 + Y**3
-        >>> F2 = X**4 + Y**3
-        >>> F3 = jnp.zeros_like(F1)
-        >>> F = jnp.stack([F1,F2,F3], axis=0)
-        >>> curlF = finitediffx.curl(F, step_size=(dx,dy,dz),  accuracy=6)
-        >>> curlF_exact = jnp.stack([F1*0,F1*0, 4*X**3 - 3*Y**2], axis=0)
-        >>> npt.assert_allclose(curlF, curlF_exact, atol=1e-7)
+        >>> import finitediffx as fdx
+        >>> import jax.numpy as jnp
+        >>> import numpy.testing as npt
+        >>> import jax
+        >>> with jax.experimental.enable_x64():
+        ...     x,y,z = [jnp.linspace(0, 1, 100)] * 3
+        ...     dx,dy,dz = x[1]-x[0], y[1]-y[0], z[1]-z[0]
+        ...     X,Y,Z = jnp.meshgrid(x,y,z, indexing="ij")
+        ...     F1 = X**2 + Y**3
+        ...     F2 = X**4 + Y**3
+        ...     F3 = jnp.zeros_like(F1)
+        ...     F = jnp.stack([F1,F2,F3], axis=0)
+        ...     curlF = fdx.curl(F, step_size=(dx,dy,dz),  accuracy=6)
+        ...     curlF_exact = jnp.stack([F1*0,F1*0, 4*X**3 - 3*Y**2], axis=0)
+        ...     npt.assert_allclose(curlF, curlF_exact, atol=1e-7)
 
         >>> # Curl of 2D vector field is defined as
         >>> x,y = [jnp.linspace(-1,1,50)]*2
@@ -699,7 +714,7 @@ def curl(
         >>> F1 = jnp.sin(Y)
         >>> F2 = jnp.cos(X)
         >>> F = jnp.stack([F1,F2], axis=0)
-        >>> curl = curl_2d(F, accuracy=4, step_size=dx)
+        >>> curl = fdx.curl(F, accuracy=4, step_size=dx)
     """
 
     accuracy = _check_and_return(accuracy, array.ndim - 1, "accuracy")
@@ -717,7 +732,8 @@ def curl(
             keepdims=keepdims,
         )
 
-    msg = f"`curl` is only implemented for 2D and 3D vector fields, got {array.ndim}D"
-    msg += "for 2D vector fields, the leading axis must have a shape=2, "
-    msg += "for 3D vector fields, the leading axis must have a shape=3"
-    raise ValueError(msg)
+    raise ValueError(
+        f"`curl` is only implemented for 2D and 3D vector fields, got {array.ndim}D"
+        "for 2D vector fields, the leading axis must have a shape=2, "
+        "for 3D vector fields, the leading axis must have a shape=3"
+    )

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="asem00@kaist.ac.kr",
     keywords="python jax",
     packages=find_namespace_packages(exclude=['examples", "tests","experimental']),
-    install_requires=["jax>=0.4.0"],
+    install_requires=["jax>=0.4.0", "typing-extensions"],
     zip_safe=False,  # Required for full installation.
     python_requires=">=3.8",
     classifiers=[


### PR DESCRIPTION
- Add `define_fdjvp` following [JEP](https://github.com/google/jax/issues/15425)
- Make `fgrad` accepts a tuple of step sizes and offsets for each argnum.
- Remove `accuracy` in `fgrad` to eliminate the mutually exclusive argument, instead uses `offset=fdx.Offset(accuracy=...)` to auto-generate the required offsets (shifted eval points)
- Fix the docstring for all files.