### PR TITLE
fgrad with pytrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Implements :
 
 **Function transformation:**
 
-- `fgrad`: similar to `jax.grad` but with finite difference approximation.
+- `fgrad`, and `value_and_fgrad` : similar to `jax.grad` and `jax.value_and_grad` but with finite difference approximation.
 - `define_fdjvp`: define `custom_jvp` rules using finite difference approximation (see example below).
 
 ## 🛠️ Installation<a id="installation"></a>
@@ -260,6 +260,25 @@ with enable_x64():
 # 402.0000951997936
 # 402.0000000002219
 # 402.0
+```
+
+Also works on pytrees
+
+```python
+
+import finitediffx as fdx
+
+params = {"a":1., "b":2., "c":3.}
+
+@fdx.fgrad
+def func(params):
+    return params["a"]**2+params["b"]
+
+func(params)
+# {'a': Array(1.9995117, dtype=float32),
+#  'b': Array(0.9995117, dtype=float32),
+#  'c': Array(0., dtype=float32)}
+
 ```
 
 </details>

--- a/tests/test_fgrad.py
+++ b/tests/test_fgrad.py
@@ -207,16 +207,13 @@ def test_has_aux():
 
 
 def test_fgrad_error():
-    with pytest.raises(ValueError):
-        fgrad(lambda x: x, argnums=-1)
-
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         fgrad(lambda x: x, argnums=1.0)
 
     with pytest.raises(ValueError):
         fgrad(lambda x: x, offsets=Offset(accuracy=1))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         fgrad(lambda x: x, argnums=[1, 2])
 
 
@@ -261,3 +258,19 @@ def test_value_and_fgrad():
 
     with pytest.raises(TypeError):
         value_and_fgrad(func, has_aux="")(1.0)
+
+
+def test_fgrad_pytree():
+    params = {"a": 1.0, "b": 2.0, "c": 3.0}
+
+    def f(params):
+        return params["a"] ** 2 + params["b"]
+
+    jax.grad(f)(params), fgrad(f)(params)
+
+    dparams_fdx = fgrad(f)(params)
+    dparams_jax = jax.grad(f)(params)
+
+    npt.assert_allclose(dparams_fdx["a"], dparams_jax["a"], atol=1e-3)
+    npt.assert_allclose(dparams_fdx["b"], dparams_jax["b"], atol=1e-3)
+    npt.assert_allclose(dparams_fdx["c"], dparams_jax["c"], atol=1e-3)


### PR DESCRIPTION
This PR adds the ability to differentiate arbitrary pytrees using `fgrad`, `value_and_fgrad`

```python

import finitediffx as fdx

params = {"a":1., "b":2., "c":3.}

@fdx.fgrad
def func(params):
    return params["a"]**2+params["b"]

func(params)
# {'a': Array(1.9995117, dtype=float32),
#  'b': Array(0.9995117, dtype=float32),
#  'c': Array(0., dtype=float32)}

```