### PR TITLE
Fix pyproject.toml warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-[build-systems]
+[build-system]
 requires = ["setuptools >= 61"]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Hi, when run the following command in order to generate the wheels
```
python -m build --wheel --skip-dependency-check --no-isolation
```

shows in the following warning in the process

```console
WARNING Found 'build-systems' in pyproject.toml, did you mean 'build-system'?
* Building wheel..
```
